### PR TITLE
Add minimal Alpaca trading bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# trader
+# Trading Bot
+
+This repository contains a minimal command line trading bot that connects to the
+Alpaca API. It provides four simple trading strategies:
+
+- Moving Average Crossover (`ma`)
+- RSI with Bollinger Bands (`rsi_bb`)
+- Intraday High/Low Breakout (`breakout`)
+- EMA Pullback (`ema`)
+
+The bot is intended for educational use. It defaults to Alpaca's paper trading
+endpoint so you can paper trade safely. You must set your API credentials in the
+environment:
+
+```bash
+export APCA_API_KEY_ID="<your key>"
+export APCA_API_SECRET_KEY="<your secret>"
+# optional: export APCA_API_BASE_URL="https://paper-api.alpaca.markets"
+```
+
+Run the bot with the desired command:
+
+```bash
+# Execute a strategy with a symbol and amount of capital (USD)
+python main.py trade --strategy ma --symbol BTCUSD --amount 100
+
+# Show open positions
+python main.py positions
+
+# Close a position
+python main.py close --symbol BTCUSD
+```
+
+The code is simplified and does not include advanced risk management. Use at
+your own risk and review the source before trading with real money.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,50 @@
+import argparse
+import os
+from trading_bot import TradingBot
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Trading Bot CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    trade_parser = subparsers.add_parser(
+        "trade", help="Execute a trading strategy"
+    )
+    trade_parser.add_argument(
+        "--strategy",
+        required=True,
+        choices=["ma", "rsi_bb", "breakout", "ema"],
+    )
+    trade_parser.add_argument("--symbol", required=True)
+    trade_parser.add_argument("--amount", required=True, type=float)
+
+    subparsers.add_parser("positions", help="Show open positions")
+
+    close_parser = subparsers.add_parser("close", help="Close a position")
+    close_parser.add_argument("--symbol", required=True)
+
+    args = parser.parse_args()
+
+    api_key = os.getenv("APCA_API_KEY_ID")
+    secret_key = os.getenv("APCA_API_SECRET_KEY")
+    base_url = os.getenv(
+        "APCA_API_BASE_URL", "https://paper-api.alpaca.markets"
+    )
+
+    if not api_key or not secret_key:
+        parser.error("API credentials not set in environment variables")
+
+    bot = TradingBot(api_key, secret_key, base_url)
+
+    if args.command == "trade":
+        bot.run_strategy(args.strategy, args.symbol, args.amount)
+    elif args.command == "positions":
+        bot.show_positions()
+    elif args.command == "close":
+        bot.close_position(args.symbol)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies.py
+++ b/strategies.py
@@ -1,0 +1,79 @@
+import pandas as pd
+import numpy as np
+
+
+def ma_crossover_signal(
+    df: pd.DataFrame, short: int = 20, long: int = 50
+) -> str | None:
+    df["short_ma"] = df["close"].rolling(short).mean()
+    df["long_ma"] = df["close"].rolling(long).mean()
+    if len(df) < long + 1:
+        return None
+    if (
+        df["short_ma"].iloc[-1] > df["long_ma"].iloc[-1]
+        and df["short_ma"].iloc[-2] <= df["long_ma"].iloc[-2]
+    ):
+        return "buy"
+    if (
+        df["short_ma"].iloc[-1] < df["long_ma"].iloc[-1]
+        and df["short_ma"].iloc[-2] >= df["long_ma"].iloc[-2]
+    ):
+        return "sell"
+    return None
+
+
+def rsi(series: pd.Series, period: int = 14) -> pd.Series:
+    delta = series.diff()
+    gain = delta.clip(lower=0).rolling(period).mean()
+    loss = -delta.clip(upper=0).rolling(period).mean()
+    rs = gain / loss
+    return 100 - (100 / (1 + rs))
+
+
+def rsi_bollinger_signal(
+    df: pd.DataFrame, rsi_low: int = 30, rsi_high: int = 70, period: int = 20
+) -> str | None:
+    df["rsi"] = rsi(df["close"])
+    ma = df["close"].rolling(period).mean()
+    std = df["close"].rolling(period).std()
+    df["upper"] = ma + 2 * std
+    df["lower"] = ma - 2 * std
+    last = df.iloc[-1]
+    if last["rsi"] < rsi_low and last["close"] < last["lower"]:
+        return "buy"
+    if last["rsi"] > rsi_high and last["close"] > last["upper"]:
+        return "sell"
+    return None
+
+
+def breakout_signal(df: pd.DataFrame, buffer: float = 0.001) -> str | None:
+    if len(df) < 2:
+        return None
+    df = df.copy()
+    df["date"] = df.index.date
+    today = df.iloc[-1]
+    prev_day = df[df["date"] < today["date"]].iloc[-1]
+    high_level = prev_day["high"]
+    low_level = prev_day["low"]
+    if today["close"] > high_level * (1 + buffer):
+        return "buy"
+    if today["close"] < low_level * (1 - buffer):
+        return "sell"
+    return None
+
+
+def ema_pullback_signal(df: pd.DataFrame, period: int = 20) -> str | None:
+    df["ema"] = df["close"].ewm(span=period, adjust=False).mean()
+    if len(df) < period + 2:
+        return None
+    if (
+        df["close"].iloc[-1] > df["ema"].iloc[-1]
+        and df["close"].iloc[-2] <= df["ema"].iloc[-2]
+    ):
+        return "buy"
+    if (
+        df["close"].iloc[-1] < df["ema"].iloc[-1]
+        and df["close"].iloc[-2] >= df["ema"].iloc[-2]
+    ):
+        return "sell"
+    return None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from strategies import ma_crossover_signal
+import pandas as pd
+
+def test_import():
+    df = pd.DataFrame({'close': [1, 2, 3, 4, 5]})
+    assert ma_crossover_signal(df) is None

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -1,0 +1,77 @@
+import os
+import pandas as pd
+from alpaca_trade_api import REST
+from strategies import (
+    ma_crossover_signal,
+    rsi_bollinger_signal,
+    breakout_signal,
+    ema_pullback_signal,
+)
+
+
+class TradingBot:
+    """Simple trading bot using Alpaca API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        secret_key: str,
+        base_url: str = "https://paper-api.alpaca.markets",
+    ):
+        self.api = REST(api_key, secret_key, base_url, api_version="v2")
+        self.positions = {}
+
+    def fetch_data(
+        self, symbol: str, timeframe: str = "15Min", limit: int = 200
+    ) -> pd.DataFrame:
+        bars = self.api.get_crypto_bars(symbol, timeframe, limit=limit).df
+        return bars[bars["symbol"] == symbol]
+
+    def place_order(self, symbol: str, qty: float, side: str):
+        order = self.api.submit_order(
+            symbol=symbol,
+            qty=qty,
+            side=side,
+            type="market",
+            time_in_force="gtc",
+        )
+        self.positions[symbol] = order.id
+        print(f"Submitted {side} order for {qty} {symbol}")
+        return order
+
+    def close_position(self, symbol: str):
+        try:
+            self.api.close_position(symbol)
+            self.positions.pop(symbol, None)
+            print(f"Closed position in {symbol}")
+        except Exception as e:
+            print(f"Error closing position: {e}")
+
+    def show_positions(self):
+        positions = self.api.list_positions()
+        for p in positions:
+            print(
+                f"{p.symbol} qty={p.qty} side={p.side} unrealized_pl={p.unrealized_pl}"
+            )
+
+    def run_strategy(self, strategy: str, symbol: str, capital: float):
+        df = self.fetch_data(symbol)
+        signal = None
+        if strategy == "ma":
+            signal = ma_crossover_signal(df)
+        elif strategy == "rsi_bb":
+            signal = rsi_bollinger_signal(df)
+        elif strategy == "breakout":
+            signal = breakout_signal(df)
+        elif strategy == "ema":
+            signal = ema_pullback_signal(df)
+        else:
+            print(f"Unknown strategy {strategy}")
+            return
+        if signal:
+            price = df["close"].iloc[-1]
+            qty = capital / price
+            side = "buy" if signal == "buy" else "sell"
+            self.place_order(symbol, qty, side)
+        else:
+            print("No trading signal generated")


### PR DESCRIPTION
## Summary
- implement simple CLI `main.py` to run strategies and manage positions
- add `TradingBot` wrapper over Alpaca API
- add four example strategies in `strategies.py`
- include example usage in README
- provide smoke test for importing strategies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bf7f32d48321adc17d74f1663f56