### PR TITLE
Add combined crypto trading strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # Trading Bot
 
 This repository contains a minimal command line trading bot that connects to the
-Alpaca API. It provides four simple trading strategies:
+Alpaca API. It provides multiple trading strategies and a combined strategy that
+aggregates their signals:
 
 - Moving Average Crossover (`ma`)
 - RSI with Bollinger Bands (`rsi_bb`)
 - Intraday High/Low Breakout (`breakout`)
 - EMA Pullback (`ema`)
+- Combined strategy using all of the above (`combo`)
 
 The bot is intended for educational use. It defaults to Alpaca's paper trading
-endpoint so you can paper trade safely. You must set your API credentials in the
+endpoint so you can paper trade safely. Each order will print suggested stop
+loss and take-profit levels when available. You must set your API credentials in the
 environment:
 
 ```bash
@@ -23,6 +26,9 @@ Run the bot with the desired command:
 ```bash
 # Execute a strategy with a symbol and amount of capital (USD)
 python main.py trade --strategy ma --symbol BTCUSD --amount 100
+
+# Use the combined strategy
+python main.py trade --strategy combo --symbol BTCUSD --amount 100
 
 # Show open positions
 python main.py positions

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ def main():
     trade_parser.add_argument(
         "--strategy",
         required=True,
-        choices=["ma", "rsi_bb", "breakout", "ema"],
+        choices=["ma", "rsi_bb", "breakout", "ema", "combo"],
     )
     trade_parser.add_argument("--symbol", required=True)
     trade_parser.add_argument("--amount", required=True, type=float)

--- a/strategies.py
+++ b/strategies.py
@@ -1,10 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
 import pandas as pd
 import numpy as np
 
 
+@dataclass
+class TradeSignal:
+    """Represents a trading signal with optional risk parameters."""
+
+    action: str
+    stop: float | None = None
+    target: float | None = None
+
+
+def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Compute the Average True Range."""
+    high_low = df["high"] - df["low"]
+    high_close = (df["high"] - df["close"].shift()).abs()
+    low_close = (df["low"] - df["close"].shift()).abs()
+    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
+    return tr.rolling(period).mean()
+
+
 def ma_crossover_signal(
     df: pd.DataFrame, short: int = 20, long: int = 50
-) -> str | None:
+) -> TradeSignal | None:
     df["short_ma"] = df["close"].rolling(short).mean()
     df["long_ma"] = df["close"].rolling(long).mean()
     if len(df) < long + 1:
@@ -13,12 +34,14 @@ def ma_crossover_signal(
         df["short_ma"].iloc[-1] > df["long_ma"].iloc[-1]
         and df["short_ma"].iloc[-2] <= df["long_ma"].iloc[-2]
     ):
-        return "buy"
+        stop = df["long_ma"].iloc[-1]
+        return TradeSignal("buy", stop=stop)
     if (
         df["short_ma"].iloc[-1] < df["long_ma"].iloc[-1]
         and df["short_ma"].iloc[-2] >= df["long_ma"].iloc[-2]
     ):
-        return "sell"
+        stop = df["long_ma"].iloc[-1]
+        return TradeSignal("sell", stop=stop)
     return None
 
 
@@ -32,7 +55,7 @@ def rsi(series: pd.Series, period: int = 14) -> pd.Series:
 
 def rsi_bollinger_signal(
     df: pd.DataFrame, rsi_low: int = 30, rsi_high: int = 70, period: int = 20
-) -> str | None:
+) -> TradeSignal | None:
     df["rsi"] = rsi(df["close"])
     ma = df["close"].rolling(period).mean()
     std = df["close"].rolling(period).std()
@@ -40,13 +63,17 @@ def rsi_bollinger_signal(
     df["lower"] = ma - 2 * std
     last = df.iloc[-1]
     if last["rsi"] < rsi_low and last["close"] < last["lower"]:
-        return "buy"
+        stop = last["lower"]
+        target = ma.iloc[-1]
+        return TradeSignal("buy", stop=stop, target=target)
     if last["rsi"] > rsi_high and last["close"] > last["upper"]:
-        return "sell"
+        stop = last["upper"]
+        target = ma.iloc[-1]
+        return TradeSignal("sell", stop=stop, target=target)
     return None
 
 
-def breakout_signal(df: pd.DataFrame, buffer: float = 0.001) -> str | None:
+def breakout_signal(df: pd.DataFrame, buffer: float = 0.001) -> TradeSignal | None:
     if len(df) < 2:
         return None
     df = df.copy()
@@ -55,25 +82,58 @@ def breakout_signal(df: pd.DataFrame, buffer: float = 0.001) -> str | None:
     prev_day = df[df["date"] < today["date"]].iloc[-1]
     high_level = prev_day["high"]
     low_level = prev_day["low"]
+    atr_val = atr(df).iloc[-1]
     if today["close"] > high_level * (1 + buffer):
-        return "buy"
+        stop = today["close"] - 1.5 * atr_val
+        target = today["close"] + 2 * atr_val
+        return TradeSignal("buy", stop=stop, target=target)
     if today["close"] < low_level * (1 - buffer):
-        return "sell"
+        stop = today["close"] + 1.5 * atr_val
+        target = today["close"] - 2 * atr_val
+        return TradeSignal("sell", stop=stop, target=target)
     return None
 
 
-def ema_pullback_signal(df: pd.DataFrame, period: int = 20) -> str | None:
+def ema_pullback_signal(df: pd.DataFrame, period: int = 20) -> TradeSignal | None:
     df["ema"] = df["close"].ewm(span=period, adjust=False).mean()
     if len(df) < period + 2:
         return None
+    atr_val = atr(df).iloc[-1]
     if (
         df["close"].iloc[-1] > df["ema"].iloc[-1]
         and df["close"].iloc[-2] <= df["ema"].iloc[-2]
     ):
-        return "buy"
+        stop = df["ema"].iloc[-1] - atr_val
+        return TradeSignal("buy", stop=stop)
     if (
         df["close"].iloc[-1] < df["ema"].iloc[-1]
         and df["close"].iloc[-2] >= df["ema"].iloc[-2]
     ):
-        return "sell"
+        stop = df["ema"].iloc[-1] + atr_val
+        return TradeSignal("sell", stop=stop)
     return None
+
+
+def combined_signal(df: pd.DataFrame) -> TradeSignal | None:
+    """Aggregate signals from all strategies using majority vote."""
+
+    signals = [
+        ma_crossover_signal(df),
+        rsi_bollinger_signal(df),
+        breakout_signal(df),
+        ema_pullback_signal(df),
+    ]
+    actions = [s.action for s in signals if s]
+    if not actions:
+        return None
+    buy_count = actions.count("buy")
+    sell_count = actions.count("sell")
+    if buy_count == sell_count:
+        return None
+    action = "buy" if buy_count > sell_count else "sell"
+
+    stops = [s.stop for s in signals if s and s.stop is not None]
+    targets = [s.target for s in signals if s and s.target is not None]
+    stop = float(np.nanmean(stops)) if stops else None
+    target = float(np.nanmean(targets)) if targets else None
+    return TradeSignal(action, stop=stop, target=target)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,9 +2,19 @@ import sys
 from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from strategies import ma_crossover_signal
+from strategies import ma_crossover_signal, combined_signal
 import pandas as pd
 
 def test_import():
-    df = pd.DataFrame({'close': [1, 2, 3, 4, 5]})
-    assert ma_crossover_signal(df) is None
+    df = pd.DataFrame(
+        {
+            'close': [1, 2, 3, 4, 5],
+            'high': [1, 2, 3, 4, 5],
+            'low': [1, 1, 2, 3, 4]
+        },
+        index=pd.date_range("2020-01-01", periods=5, freq="D")
+    )
+    sig1 = ma_crossover_signal(df)
+    assert sig1 is None or hasattr(sig1, "action")
+    sig = combined_signal(df)
+    assert sig is None or hasattr(sig, "action")

--- a/trading_bot.py
+++ b/trading_bot.py
@@ -6,6 +6,8 @@ from strategies import (
     rsi_bollinger_signal,
     breakout_signal,
     ema_pullback_signal,
+    combined_signal,
+    TradeSignal,
 )
 
 
@@ -65,13 +67,19 @@ class TradingBot:
             signal = breakout_signal(df)
         elif strategy == "ema":
             signal = ema_pullback_signal(df)
+        elif strategy == "combo":
+            signal = combined_signal(df)
         else:
             print(f"Unknown strategy {strategy}")
             return
         if signal:
             price = df["close"].iloc[-1]
             qty = capital / price
-            side = "buy" if signal == "buy" else "sell"
+            side = "buy" if signal.action == "buy" else "sell"
             self.place_order(symbol, qty, side)
+            if signal.stop:
+                print(f"Suggested stop loss: {signal.stop:.2f}")
+            if signal.target:
+                print(f"Suggested take profit: {signal.target:.2f}")
         else:
             print("No trading signal generated")


### PR DESCRIPTION
## Summary
- enhance README with combined strategy info
- support a new `combo` strategy in CLI
- add risk-aware `TradeSignal` dataclass and ATR helper
- implement stop/target levels in individual strategies
- aggregate signals with `combined_signal`
- show stop/target suggestions on order placement
- test that strategies load

## Testing
- `pip install pandas numpy alpaca-trade-api`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c0f8ca8883218e766eb09cc325b0